### PR TITLE
build with all CPU's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN cd /root; git clone https://github.com/intel/gmmlib gmmlib ;\
     git clone --depth 1 -b release-1.7.0 https://github.com/google/googletest gtest ; \
     git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers khronos ; \
     cd neo/scripts/igc ; ./prepare.sh ; cd ../../.. ; \
-    mkdir build; cd build ; cmake -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release ../neo ; make -j 2
+    mkdir build; cd build ; cmake -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release ../neo ; make -j `nproc`
 CMD ["/bin/bash"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,5 +28,5 @@ git clone ../../compute-runtime neo
 pushd neo/scripts/igc ; ./prepare.sh ; popd
 mkdir build; cd build
 cmake -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release ../neo
-make -j 2 package
+make -j `nproc` package
 


### PR DESCRIPTION
Use nproc command instead of hardcoded number of CPU's

Signed-off-by: Jacek Danecki <jacek.m.danecki@gmail.com>